### PR TITLE
refine SME chat agent labeling

### DIFF
--- a/client/src/components/ChatAgent.jsx
+++ b/client/src/components/ChatAgent.jsx
@@ -47,7 +47,7 @@ export default function ChatAgent() {
                             value={input}
                             onChange={(e) => setInput(e.target.value)}
                             onKeyDown={(e) => e.key === 'Enter' && send()}
-                            placeholder='Ask about AI services…'
+                            placeholder='Ask about AI services for SMEs…'
                         />
                         <button onClick={send}>Send</button>
                         <button onClick={() => setOpen(false)}>×</button>
@@ -55,7 +55,7 @@ export default function ChatAgent() {
                 </div>
             ) : (
                 <button className='chat-toggle' onClick={() => setOpen(true)}>
-                    Chat
+                    AI SME Chat
                 </button>
             )}
         </div>

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,8 @@ const PORT = process.env.PORT || 4000
 // Agent that answers questions about AI services for SMEs
 const chatAgent = new Agent({
     name: 'SME AI Advisor',
-    instructions: 'You answer questions about AI services for small and medium-sized enterprises in a concise, helpful manner.',
+    instructions:
+        'You provide concise, helpful answers about AI services for small and medium-sized enterprises (SMEs).',
 })
 
 app.use(cors())


### PR DESCRIPTION
## Summary
- Clarify SME chat widget labeling and placeholder copy
- Refine server agent instructions for concise SME AI responses

## Testing
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` (client)
- `npm test` (server) *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b7c8fa7210832891c7cc6b5047af0c