### PR TITLE
feat: add floating chat toggle

### DIFF
--- a/client/src/components/ChatAgent.jsx
+++ b/client/src/components/ChatAgent.jsx
@@ -7,7 +7,10 @@ export default function ChatAgent() {
     const listRef = useRef(null)
 
     useEffect(() => {
-        listRef.current?.scrollTo(0, listRef.current.scrollHeight)
+        const el = listRef.current
+        if (el) {
+            el.scrollTop = el.scrollHeight
+        }
     }, [messages])
 
     const send = async () => {
@@ -53,8 +56,13 @@ export default function ChatAgent() {
                         <button onClick={() => setOpen(false)}>×</button>
                     </div>
                 </div>
-            ) : (
-                <button className='chat-toggle' onClick={() => setOpen(true)}>
+            ) : null}
+            {!open && (
+                <button
+                    className='chat-toggle'
+                    onClick={() => setOpen(true)}
+                    aria-label='Open AI SME chat'
+                >
                     AI SME Chat
                 </button>
             )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -125,7 +125,7 @@ button:focus-visible {
 /* Chat agent widget */
 .chat-agent {
   position: fixed;
-  bottom: 1rem;
+  top: 1rem;
   right: 1rem;
   z-index: 1000;
 }


### PR DESCRIPTION
## Summary
- place chat launcher in the top-right corner
- ensure chat messages scroll and toggle bubble via a button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b7cf191a708328a8075d3cef159bc6