### PR TITLE
Handle agent connection errors

### DIFF
--- a/client/src/components/ChatAgent.jsx
+++ b/client/src/components/ChatAgent.jsx
@@ -25,11 +25,12 @@ export default function ChatAgent() {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ question })
             })
-            const data = await res.json()
-            setMessages(m => [
-                ...m,
-                { from: 'bot', text: data.answer || data.error || 'Error' }
-            ])
+            const data = await res.json().catch(() => ({}))
+            if (!res.ok || data.error) {
+                setMessages(m => [...m, { from: 'bot', text: '⚠️ Service unavailable' }])
+            } else {
+                setMessages(m => [...m, { from: 'bot', text: data.answer || 'No answer' }])
+            }
         } catch {
             setMessages(m => [...m, { from: 'bot', text: '⚠️ Network error' }])
         } finally {

--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ app.post('/api/agent', async (req, res) => {
         res.json({ answer: result.finalOutput })
     } catch (e) {
         console.error(e)
-        res.status(500).json({ error: e.message || 'agent_error' })
+        res.status(502).json({ error: 'agent_unavailable' })
     }
 })
 


### PR DESCRIPTION
## Summary
- return generic message when agent backend fails instead of low-level ECONNRESET
- show friendly fallback in ChatAgent when agent is unavailable

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test` (client) *(fails: Missing script: "test")*
- `npm run lint` (client)


------
https://chatgpt.com/codex/tasks/task_e_68bf949d3c3c8328b82adfe4cf3f8458