### PR TITLE
Expose API port and harden server image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-    expose:
-      - "3000"
+    ports:
+      - "3000:3000"
 
   web:
     build:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,12 +3,13 @@ WORKDIR /app
 
 # Install only production deps for faster, smaller images
 COPY package*.json ./
-RUN npm ci --only=production || npm i --only=production
+RUN npm ci --omit=dev || npm i --omit=dev
 
 # Copy source
 COPY . .
 
 # Expose internal port + start
+ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
 CMD ["node","index.js"]


### PR DESCRIPTION
## Summary
- map backend API port 3000 to the host in docker compose
- streamline server Dockerfile to install only production dependencies and set NODE_ENV

## Testing
- `npm run lint`
- `node server/index.js` *(killed after startup)*
- `docker compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf9a05f45483288a00b4d84f696cf5