### PR TITLE
Expose API port and harden server image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     environment:
       - NODE_ENV=production
       - PORT=3000
-    expose:
-      - "3000"
+    ports:
+      - "3000:3000"
 
   web:
     build:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,12 +3,13 @@ WORKDIR /app
 
 # Install only production deps for faster, smaller images
 COPY package*.json ./
-RUN npm ci --only=production || npm i --only=production
+RUN npm ci --omit=dev || npm i --omit=dev
 
 # Copy source
 COPY . .
 
 # Expose internal port + start
+ENV NODE_ENV=production
 ENV PORT=3000
 EXPOSE 3000
 CMD ["node","index.js"]

--- a/server/index.js
+++ b/server/index.js
@@ -43,8 +43,7 @@ app.post('/api/contact', (req, res) => {
 })
 
 // SME AI services agent endpoint
-app.post('/api/agent', async (req, res) => {
-    const { question } = req.body || {}
+async function handleAgent(question, res) {
     if (!question?.trim()) return res.status(400).json({ error: 'Missing question' })
     try {
         const result = await run(chatAgent, question)
@@ -53,6 +52,17 @@ app.post('/api/agent', async (req, res) => {
         console.error(e)
         res.status(502).json({ error: 'agent_unavailable' })
     }
+}
+
+app.post('/api/agent', (req, res) => {
+    const { question } = req.body || {}
+    handleAgent(question, res)
+})
+
+// lightweight GET variant for quick tests
+app.get('/api/agent', (req, res) => {
+    const question = req.query.question || req.query.q
+    handleAgent(typeof question === 'string' ? question : undefined, res)
 })
 
 // n8n webhook trigger (GET passthrough)


### PR DESCRIPTION
## Summary
- map backend API port 3000 to the host in docker compose
- streamline server Dockerfile to install only production dependencies and set NODE_ENV
- support GET requests on `/api/agent` for easy browser testing

## Testing
- `npm run lint` (from `client/`)
- `node server/index.js` *(killed after startup)*
- `docker compose config` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bf9a05f45483288a00b4d84f696cf5