### PR TITLE
fix: prevent mobile zoom in chat input

### DIFF
--- a/client/src/components/ChatAgent.css
+++ b/client/src/components/ChatAgent.css
@@ -100,6 +100,7 @@
   border: 1px solid var(--border);
   background: #0f1622;
   color: #fff;
+  font-size: 16px; /* Prevent mobile browsers from zooming on focus */
 }
 .chat-controls button {
   background: var(--link);


### PR DESCRIPTION
## Summary
- stop chat input from triggering browser zoom on focus by using a 16px font-size

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c02a64f9b0832897af1552c20a6385