### PR TITLE
feat: enable agent-based text summarization

### DIFF
--- a/client/src/pages/Demos.jsx
+++ b/client/src/pages/Demos.jsx
@@ -34,8 +34,11 @@ export default function Demos() {
             {error && <div className="card" style={{ borderColor: '#ff6b6b' }}>Error: {error}</div>}
             {result && (
                 <div className="card">
-                    <h3>Result</h3>
-                    <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(result, null, 2)}</pre>
+                    <h3>Summary</h3>
+                    <p style={{ whiteSpace: 'pre-wrap' }}>{result.summary}</p>
+                    {typeof result.length === 'number' && (
+                        <p style={{ fontSize: 12, opacity: 0.7 }}>({result.length} chars)</p>
+                    )}
                 </div>
             )}
         </section>


### PR DESCRIPTION
## Summary
- add dedicated agent for summarizing arbitrary text
- expose new agent-powered `/api/demo/summarize` endpoint
- show returned summary cleanly in the demos page

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c040615d808328bb47d782978e8c34