### PR TITLE
Refactor Demos page into modular demo routes

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,7 @@ import ChatAgent from './components/ChatAgent.jsx'
 import Home from './pages/Home.jsx'
 import Services from './pages/Services.jsx'
 import Demos from './pages/Demos.jsx'
+import Summarize from './pages/demos/Summarize.jsx'
 import About from './pages/About.jsx'
 import Contact from './pages/Contact.jsx'
 import NotFound from './pages/NotFound.jsx'
@@ -20,6 +21,7 @@ export default function App() {
           <Route path="/" element={<Home />} />
           <Route path="/services" element={<Services />} />
           <Route path="/demos" element={<Demos />} />
+          <Route path="/demos/summarize" element={<Summarize />} />
           <Route path="/about" element={<About />} />
           {/* <Route path="/n8n-test" element={<N8nTest />} /> */}
 

--- a/client/src/pages/Demos.jsx
+++ b/client/src/pages/Demos.jsx
@@ -1,46 +1,23 @@
-import { useState } from 'react'
-import { api } from '../lib/api.js'
-import Loader from '../components/Loader.jsx'
+import { Link } from 'react-router-dom'
 
 export default function Demos() {
-    const [text, setText] = useState('Paste a paragraph, and we will summarize it.')
-    const [result, setResult] = useState(null)
-    const [loading, setLoading] = useState(false)
-    const [error, setError] = useState(null)
-
-    const runDemo = async () => {
-        setError(null); setResult(null); setLoading(true)
-        try {
-            const res = await api.post('/demo/summarize', { text })
-            setResult(res.data)
-        } catch (e) {
-            setError(e.message)
-        } finally { setLoading(false) }
-    }
+    const demos = [
+        {
+            title: 'Demo: Summarize text',
+            description: 'Summarize a paragraph via /api/demo/summarize.',
+            path: '/demos/summarize'
+        }
+    ]
 
     return (
         <section className="grid" style={{ gap: 16 }}>
-            <div className="card">
-                <h2 style={{ marginTop: 0 }}>Demo: Summarize text</h2>
-                <p>This calls <code>/api/demo/summarize</code> on your server and returns a concise summary.</p>
-                <textarea className="textarea" value={text} onChange={(e) => setText(e.target.value)} />
-                <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
-                    <button className="btn" onClick={runDemo}>Summarize</button>
-                    <a className="btn" href="/api/health" target="_blank" rel="noreferrer">Health check</a>
-                </div>
-            </div>
-
-            {loading && <Loader text="Summarizing…" />}
-            {error && <div className="card" style={{ borderColor: '#ff6b6b' }}>Error: {error}</div>}
-            {result && (
-                <div className="card">
-                    <h3>Summary</h3>
-                    <p style={{ whiteSpace: 'pre-wrap' }}>{result.summary}</p>
-                    {typeof result.length === 'number' && (
-                        <p style={{ fontSize: 12, opacity: 0.7 }}>({result.length} chars)</p>
-                    )}
-                </div>
-            )}
+            {demos.map((demo) => (
+                <Link key={demo.path} to={demo.path} className="card" style={{ textDecoration: 'none', color: 'inherit' }}>
+                    <h2 style={{ marginTop: 0 }}>{demo.title}</h2>
+                    <p>{demo.description}</p>
+                </Link>
+            ))}
         </section>
     )
 }
+

--- a/client/src/pages/demos/Summarize.jsx
+++ b/client/src/pages/demos/Summarize.jsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { api } from '../../lib/api.js'
+import Loader from '../../components/Loader.jsx'
+
+export default function Summarize() {
+    const navigate = useNavigate()
+    const [text, setText] = useState('Paste a paragraph, and we will summarize it.')
+    const [result, setResult] = useState(null)
+    const [loading, setLoading] = useState(false)
+    const [error, setError] = useState(null)
+
+    const runDemo = async () => {
+        setError(null); setResult(null); setLoading(true)
+        try {
+            const res = await api.post('/demo/summarize', { text })
+            setResult(res.data)
+        } catch (e) {
+            setError(e.message)
+        } finally { setLoading(false) }
+    }
+
+    return (
+        <section className="grid" style={{ gap: 16 }}>
+            <button className="btn" onClick={() => navigate('/demos')} style={{ maxWidth: 'fit-content' }}>&larr; Back</button>
+            <div className="card">
+                <h2 style={{ marginTop: 0 }}>Demo: Summarize text</h2>
+                <p>This calls <code>/api/demo/summarize</code> on your server and returns a concise summary.</p>
+                <textarea className="textarea" value={text} onChange={(e) => setText(e.target.value)} />
+                <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
+                    <button className="btn" onClick={runDemo}>Summarize</button>
+                    <a className="btn" href="/api/health" target="_blank" rel="noreferrer">Health check</a>
+                </div>
+            </div>
+
+            {loading && <Loader text="Summarizing…" />}
+            {error && <div className="card" style={{ borderColor: '#ff6b6b' }}>Error: {error}</div>}
+            {result && (
+                <div className="card">
+                    <h3>Summary</h3>
+                    <p style={{ whiteSpace: 'pre-wrap' }}>{result.summary}</p>
+                    {typeof result.length === 'number' && (
+                        <p style={{ fontSize: 12, opacity: 0.7 }}>({result.length} chars)</p>
+                    )}
+                </div>
+            )}
+        </section>
+    )
+}
+


### PR DESCRIPTION
## Summary
- Extract Summarize Text demo into its own page
- Add router entry and back navigation for the Summarize demo
- Display demo cards on the main Demos page for modular expansion

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c10050ba5c8328af20a3f6d8f40491