### PR TITLE
style: add padding below navbar

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
   return (
     <div className="app-shell">
       <NavBar />
-      <main className="container">
+      <main className="container main-content">
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/services" element={<Services />} />

--- a/client/src/styles/index.css
+++ b/client/src/styles/index.css
@@ -38,6 +38,11 @@ body {
   width: min(1080px, 92%);
   margin: 32px auto;
 }
+
+/* ensure main content clears the fixed navbar */
+.main-content {
+  padding-top: 64px;
+}
 .navbar {
   display: flex;
   gap: 16px;


### PR DESCRIPTION
## Summary
- prevent fixed NavBar from obscuring page content by adding a padded main container

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c102486b908328bd6305e850c6aa90