### PR TITLE
Add placeholder image for summarize demo

### DIFF
--- a/client/src/pages/Demos.jsx
+++ b/client/src/pages/Demos.jsx
@@ -5,7 +5,8 @@ export default function Demos() {
         {
             title: 'Demo: Summarize text',
             description: 'Summarize a paragraph via /api/demo/summarize.',
-            path: '/demos/summarize'
+            path: '/demos/summarize',
+            image: '/summarize-placeholder.png'
         }
     ]
 
@@ -13,6 +14,7 @@ export default function Demos() {
         <section className="grid" style={{ gap: 16 }}>
             {demos.map((demo) => (
                 <Link key={demo.path} to={demo.path} className="card" style={{ textDecoration: 'none', color: 'inherit' }}>
+                    <img src={demo.image} alt={demo.title} style={{ width: '100%', height: 'auto', marginBottom: 12 }} />
                     <h2 style={{ marginTop: 0 }}>{demo.title}</h2>
                     <p>{demo.description}</p>
                 </Link>

--- a/client/src/pages/demos/Summarize.jsx
+++ b/client/src/pages/demos/Summarize.jsx
@@ -26,6 +26,7 @@ export default function Summarize() {
             <div className="card">
                 <h2 style={{ marginTop: 0 }}>Demo: Summarize text</h2>
                 <p>This calls <code>/api/demo/summarize</code> on your server and returns a concise summary.</p>
+                <img src="/summarize-placeholder.png" alt="Summarize text demo" style={{ width: '100%', height: 'auto', marginBottom: 12 }} />
                 <textarea className="textarea" value={text} onChange={(e) => setText(e.target.value)} />
                 <div style={{ display: 'flex', gap: 12, marginTop: 12 }}>
                     <button className="btn" onClick={runDemo}>Summarize</button>


### PR DESCRIPTION
## Summary
- add configurable placeholder image for the Summarize text demo listing
- display placeholder image within the Summarize demo page
- remove placeholder image asset so users can provide their own later

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1049000b88328b97a1a9aeb7ff0a1