### PR TITLE
Add n8n webhook chat demo

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import Services from './pages/Services.jsx'
 import Demos from './pages/Demos.jsx'
 import Summarize from './pages/demos/Summarize.jsx'
 import WhatsAppAgent from './pages/demos/WhatsAppAgent.jsx'
+import WebhookChat from './pages/demos/WebhookChat.jsx'
 import About from './pages/About.jsx'
 import Contact from './pages/Contact.jsx'
 import NotFound from './pages/NotFound.jsx'
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/demos" element={<Demos />} />
           <Route path="/demos/summarize" element={<Summarize />} />
           <Route path="/demos/whatsapp" element={<WhatsAppAgent />} />
+          <Route path="/demos/webhook-chat" element={<WebhookChat />} />
           <Route path="/about" element={<About />} />
           {/* <Route path="/n8n-test" element={<N8nTest />} /> */}
 

--- a/client/src/pages/Demos.jsx
+++ b/client/src/pages/Demos.jsx
@@ -13,6 +13,12 @@ export default function Demos() {
             description: 'Chat with an AI via /api/demo/whatsapp.',
             path: '/demos/whatsapp',
             image: '/whatsapp-placeholder.png'
+        },
+        {
+            title: 'Demo: n8n webhook chat',
+            description: 'Test messaging through an n8n workflow.',
+            path: '/demos/webhook-chat',
+            image: '/summarize-placeholder.png'
         }
     ]
 

--- a/client/src/pages/demos/WebhookChat.jsx
+++ b/client/src/pages/demos/WebhookChat.jsx
@@ -1,0 +1,137 @@
+import { useState, useRef, useEffect } from 'react'
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '/api'
+
+export default function WebhookChat() {
+    const [input, setInput] = useState('')
+    const [messages, setMessages] = useState([
+        { from: 'bot', text: 'Hi! Messages here are sent to an n8n webhook.' }
+    ])
+    const [sending, setSending] = useState(false)
+    const listRef = useRef(null)
+
+    useEffect(() => {
+        const el = listRef.current
+        if (el) el.scrollTop = el.scrollHeight
+    }, [messages])
+
+    const send = async () => {
+        const text = input.trim()
+        if (!text || sending) return
+        setMessages(m => [...m, { from: 'user', text }])
+        setInput('')
+        setSending(true)
+        try {
+            const res = await fetch(`${API_BASE}/n8n/chat`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    channel: 'web_demo',
+                    message: text,
+                    ts: Date.now(),
+                }),
+            })
+            const ct = res.headers.get('content-type') || ''
+            let reply = ''
+            if (ct.includes('application/json')) {
+                const data = await res.json()
+                reply = typeof data === 'string' ? data : JSON.stringify(data, null, 2)
+            } else {
+                reply = await res.text()
+            }
+            setMessages(m => [...m, { from: 'bot', text: reply || 'OK' }])
+        } catch (e) {
+            setMessages(m => [...m, { from: 'bot', text: '⚠️ Network error: ' + e.message }])
+        } finally {
+            setSending(false)
+        }
+    }
+
+    return (
+        <div style={styles.wrap}>
+            <div style={styles.chatBox}>
+                <div style={styles.header}>n8n Webhook Chat Test</div>
+                <div style={styles.messages} ref={listRef}>
+                    {messages.map((m, i) => (
+                        <div key={i} style={{ ...styles.msg, ...(m.from === 'user' ? styles.user : styles.bot) }}>
+                            {m.text}
+                        </div>
+                    ))}
+                    {sending && <div style={{ ...styles.msg, ...styles.bot }}>…sending…</div>}
+                </div>
+                <div style={styles.controls}>
+                    <input
+                        style={styles.input}
+                        value={input}
+                        onChange={e => setInput(e.target.value)}
+                        onKeyDown={e => e.key === 'Enter' && send()}
+                        placeholder="Type a message…"
+                    />
+                    <button style={styles.button} onClick={send} disabled={sending}>Send</button>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const styles = {
+    wrap: { display: 'grid', placeItems: 'center', padding: '32px 16px' },
+    chatBox: {
+        width: 560,
+        maxWidth: '100%',
+        border: '1px solid var(--border)',
+        borderRadius: 12,
+        overflow: 'hidden',
+        background: 'var(--bg)',
+        color: 'var(--text)',
+        boxShadow: '0 8px 28px rgba(0,0,0,0.35)',
+    },
+    header: {
+        padding: '14px 16px',
+        borderBottom: '1px solid var(--border)',
+        fontWeight: 700,
+    },
+    messages: {
+        height: 380,
+        overflowY: 'auto',
+        padding: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        background: '#20242b',
+    },
+    msg: {
+        maxWidth: '80%',
+        padding: '8px 12px',
+        borderRadius: 10,
+        whiteSpace: 'pre-wrap',
+        lineHeight: 1.4,
+        fontSize: 14,
+    },
+    user: { alignSelf: 'flex-end', background: '#2e3a52', color: '#fff' },
+    bot: { alignSelf: 'flex-start', background: '#333d4f', color: '#fff' },
+    controls: {
+        display: 'flex',
+        gap: 8,
+        padding: 10,
+        borderTop: '1px solid var(--border)',
+        background: '#1c1f24',
+    },
+    input: {
+        flex: 1,
+        padding: '10px 12px',
+        borderRadius: 8,
+        border: '1px solid var(--border)',
+        background: '#0f1622',
+        color: '#fff',
+    },
+    button: {
+        padding: '10px 14px',
+        borderRadius: 8,
+        border: 'none',
+        background: 'var(--link)',
+        color: '#fff',
+        fontWeight: 700,
+        cursor: 'pointer',
+    },
+}


### PR DESCRIPTION
## Summary
- forward POST requests to an n8n workflow via `/api/n8n/chat`
- add WebhookChat page with simple chatbox for testing the webhook
- link the webhook chat demo from the Demos list and configure routing

## Testing
- `npm test` *(client: Missing script: "test")*
- `npm run lint`
- `npm test` *(server: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c25500b13483288eb66125639772f8