### PR TITLE
Add sample environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Server configuration
+PORT=3000
+ROOT_DOMAIN=example.com
+
+# OpenAI configuration
+OPENAI_API_KEY=sk-your-openai-api-key
+
+# n8n webhook configuration
+N8N_WEBHOOK_URL=https://n8n.example.com/webhook/your-trigger-id
+N8N_CHAT_WEBHOOK=https://n8n.example.com/webhook/your-chat-id
+
+# Frontend API configuration
+VITE_API_BASE_URL=/api

--- a/server/index.js
+++ b/server/index.js
@@ -7,6 +7,7 @@ import { Agent, run } from '@openai/agents'
 const app = express()
 const PORT = process.env.PORT || 3000
 const N8N_CHAT_WEBHOOK =
+    process.env.N8N_CHAT_WEBHOOK ||
     'https://n8n.workflow.sg/webhook/ca7eaba9-e5ef-48a3-bb40-373b4970a778'
 
 // console.log('N8N_CHAT_WEBHOOK =', N8N_CHAT_WEBHOOK)


### PR DESCRIPTION
## Summary
- allow overriding the n8n chat webhook with an environment variable
- provide a template .env.example with the required configuration keys

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccea55fbe48328b56e9e533c6b388a